### PR TITLE
RFPD-46544: Added passive mode + additional plugin dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 bin/
 build/
 develop-eggs/

--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -51,7 +51,7 @@ class WAFW00F(waftoolsengine):
                 continue
             if attack == 'xss':
                 params[create_random_param_name()] = self.xsstring
-            elif attack == 'sqi':
+            elif attack == 'sqli':
                 params[create_random_param_name()] = self.sqlistring
             elif attack == 'lfi':
                 params[create_random_param_name()] = self.lfistring
@@ -94,7 +94,7 @@ class WAFW00F(waftoolsengine):
     def centralAttack(self):
         return self.Request(
             path=self.path,
-            params=self._build_params(['xss','sqi','lfi'])
+            params=self._build_params(['xss','sqli','lfi'])
         )
 
     def sqliAttack(self):

--- a/wafw00f/manager.py
+++ b/wafw00f/manager.py
@@ -13,11 +13,15 @@ def load_plugins():
     get_path = partial(os.path.join, here)
     plugin_dir = get_path('plugins')
 
+    searchpath = [plugin_dir]
+    if os.environ.get('WAFW00F_PLUGIN_DIR'):
+        searchpath.append(os.environ.get('WAFW00F_PLUGIN_DIR'))
+
     plugin_base = PluginBase(
         package='wafw00f.plugins', searchpath=[plugin_dir]
     )
     plugin_source = plugin_base.make_plugin_source(
-        searchpath=[plugin_dir], persist=True
+        searchpath=searchpath, persist=True
     )
 
     plugin_dict = {}


### PR DESCRIPTION
By specifying --passive-only it will not issue XSS,XXE,LFI,SQLI attack payloads
Can be individually disabled as well via --no-xss,--no-sqli,--no-lfi

Additionally set WAFW00F_PLUGIN_DIR will allow for additional plugins to be loaded

# Test notes

## Disabling active checks

```
docker run --rm --net host wafw00f --verbose https://meet.40two.org/ | 2>&1 grep -i 'disabled\|Number'
  __import__('pkg_resources').run_script('wafw00f==2.2.0', 'wafw00f')
[~] Number of requests: 7


➜  wafw00f git:(feature/RFPD-46544-passive) ✗ docker run --rm --net host wafw00f --verbose --passive-only https://meet.40two.org/ | 2>&1 grep -i 'disabled\|Number'
WARNING:wafw00f:XSS attack is disabled
WARNING:wafw00f:LFI attack is disabled
WARNING:wafw00f:SQLi attack is disabled
[~] Number of requests: 4
```

## Custom Plugin DIR

without:
docker run --rm wafw00f https://www.securitytrails.com/ --test "Josh's Great Waf" 
[-] WAF Josh's Great Waf was not found in our list

with:
docker run --rm -v $PWD/../extra_plugins:/opt/wafwoofplugins -e WAFW00F_PLUGIN_DIR=/opt/wafwoofplugins wafw00f https://www.securitytrails.com/ --test "Josh's Great Waf"

[+] The site https://www.securitytrails.com/ is behind Josh's Great Waf WAF.
