### PR TITLE
Adding Fastly NGWAF plugin

### DIFF
--- a/wafw00f/plugins/fastly_ngwaf.py
+++ b/wafw00f/plugins/fastly_ngwaf.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+NAME = 'Fastly Next-Gen WAF (Fastly)'
+
+
+def is_waf(self):
+    if self.matchHeader(('X-SigSci-AgentResponse', r'.+'), attack=False):
+        return True
+
+    return False

--- a/wafw00f/wafprio.py
+++ b/wafw00f/wafprio.py
@@ -65,6 +65,7 @@ wafdetectionsprio = [
 	'Envoy (EnvoyProxy)',
 	'Expression Engine (EllisLab)',
 	'Fastly (Fastly CDN)',
+	'Fastly NGWAF',
 	'FirePass (F5 Networks)',
 	'FortiGate (Fortinet)',
 	'FortiGuard (Fortinet)',


### PR DESCRIPTION
With permission we were able to test this on a real Fastly NGWAF.
The plugin is a translation of an existing nuclei template: https://github.com/algorocom/ASI-nuclei-templates/blob/e68424e1123eed337b3ca446487101b33022cc86/asi-templates/wafs/fastly-ngwaf.yaml

```
wafw00f -t 'Fastly Next-Gen WAF (Fastly)' services.sp.cfahome.com

                   ______
                  /      \
                 (  Woof! )
                  \  ____/                      )
                  ,,                           ) (_
             .-. -    _______                 ( |__|
            ()``; |==|_______)                .)|__|
            / ('        /|\                  (  |__|
        (  /  )        / | \                  . |__|
         \(_)_))      /  |  \                   |__|

                    ~ WAFW00F : v2.3.1 ~
    The Web Application Firewall Fingerprinting Toolkit
    
[*] Checking https://services.sp.cfahome.com
[+] The site https://services.sp.cfahome.com is behind Fastly Next-Gen WAF (Fastly) WAF.
```