### PR TITLE
Fix name mismatch

### DIFF
--- a/wafw00f/wafprio.py
+++ b/wafw00f/wafprio.py
@@ -65,7 +65,7 @@ wafdetectionsprio = [
 	'Envoy (EnvoyProxy)',
 	'Expression Engine (EllisLab)',
 	'Fastly (Fastly CDN)',
-	'Fastly NGWAF',
+	'Fastly Next-Gen WAF (Fastly)',
 	'FirePass (F5 Networks)',
 	'FortiGate (Fortinet)',
 	'FortiGuard (Fortinet)',


### PR DESCRIPTION
**Issue**:

```
wafw00f services.sp.cfahome.com

                ______
               /      \
              (  W00f! )
               \  ____/
               ,,    __            404 Hack Not Found
           |`-.__   / /                      __     __
           /"  _/  /_/                       \ \   / /
          *===*    /                          \ \_/ /  405 Not Allowed
         /     )__//                           \   /
    /|  /     /---`                        403 Forbidden
    \\/`   \ |                                 / _ \
    `\    /_\\_              502 Bad Gateway  / / \ \  500 Internal Error
      `_____``-`                             /_/   \_\\

                        ~ WAFW00F : v2.3.1 ~
        The Web Application Firewall Fingerprinting Toolkit
    
[*] Checking https://services.sp.cfahome.com/
Traceback (most recent call last):
  File "/Users/janarneson/py_envs/wafwoof/bin/wafw00f", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages/wafw00f/main.py", line 543, in main
    waf, xurl = attacker.identwaf(options.findall)
                ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages/wafw00f/main.py", line 304, in identwaf
    if self.wafdetections[wafvendor](self):
       ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'Fastly NGWAF'
```

There was a name mismatch between what was put into ```wafprio.py``` vs the name used by the new plugin and how the dictionary of wafdetections gets built.

This is my bad. The reason I didn't catch this in my testing is because I was testing off of the public wafw00f and not the forked version.

So luckily easy fix, as you can see below I reinstall and test based off the RF wafw00f repo, and we now work as expected.

```
pip install .                                   
Processing /Users/janarneson/src/recorded_future/wafw00f
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: requests in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from wafw00f==2.3.1) (2.32.3)
Requirement already satisfied: pluginbase in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from wafw00f==2.3.1) (1.0.1)
Requirement already satisfied: charset-normalizer<4,>=2 in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from requests->wafw00f==2.3.1) (3.4.2)
Requirement already satisfied: idna<4,>=2.5 in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from requests->wafw00f==2.3.1) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from requests->wafw00f==2.3.1) (2.4.0)
Requirement already satisfied: certifi>=2017.4.17 in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from requests->wafw00f==2.3.1) (2025.4.26)
Requirement already satisfied: PySocks!=1.5.7,>=1.5.6 in /Users/janarneson/py_envs/wafwoof/lib/python3.13/site-packages (from requests[socks]->wafw00f==2.3.1) (1.7.1)
Building wheels for collected packages: wafw00f
  Building wheel for wafw00f (pyproject.toml) ... done
  Created wheel for wafw00f: filename=wafw00f-2.3.1-py3-none-any.whl size=92119 sha256=f7328464710945c2971e4242aba9ee84fa40e005944e7503b700ac0322530eb2
  Stored in directory: /private/var/folders/6k/4ch3mhps02dgpfg5ns0dh9cc0000gn/T/pip-ephem-wheel-cache-p6j6_xc1/wheels/06/79/82/61f8a74f8bcf7ae11eac140727d30e239b03a3fe8b2038e670
Successfully built wafw00f
Installing collected packages: wafw00f
  Attempting uninstall: wafw00f
    Found existing installation: wafw00f 2.3.1
    Uninstalling wafw00f-2.3.1:
      Successfully uninstalled wafw00f-2.3.1
Successfully installed wafw00f-2.3.1
(wafwoof) janarneson@johnathanarneson-MacBook-Pro-646N wafw00f % wafw00f services.sp.cfahome.com  

                 ?              ,.   (   .      )        .      "
         __        ??          ("     )  )'     ,'        )  . (`     '`
    (___()'`;   ???          .; )  ' (( (" )    ;(,     ((  (  ;)  "  )")
    /,___ /`                 _"., ,._'_.,)_(..,( . )_  _' )_') (. _..( ' )
    \\   \\                 |____|____|____|____|____|____|____|____|____|

                                ~ WAFW00F : v2.3.1 ~
                    ~ Sniffing Web Application Firewalls since 2014 ~

[*] Checking https://services.sp.cfahome.com
[+] The site https://services.sp.cfahome.com is behind Fastly Next-Gen WAF (Fastly) WAF.
[~] Number of requests: 2
```


Also git log to show clearly I'm in the right repo:

```
commit 679925a03c44e7f03539efb5d7ecb92d6bd365b4 (HEAD -> fix_fastly_plugin, origin/fix_fastly_plugin)
Author: Johnathan Arneson <johnathan.arneson@recordedfuture.com>
Date:   Tue May 27 15:45:20 2025 -0400

    Fix name mismatch

commit e3676c91f19dd0edf0f07d1e4fc42a39c64c7c2f (tag: v2.3.3-asi-2b94868, upstream/main, origin/add_fastly_ngwaf_plugin, add_fastly_ngwaf_plugin)
Merge: 8a7c919 b2ca3c4
Author: Arneson <johnathan.arneson@recordedfuture.com>
Date:   Tue May 27 14:17:59 2025 -0400

    Merge pull request #2 from arneson-recordedfuture/add_fastly_ngwaf_plugin
    
    Adding Fastly NGWAF plugin

commit b2ca3c4ddac00f3a0e0b6ac690d149383ebb4dd2 (master)
Author: Johnathan Arneson <johnathan.arneson@recordedfuture.com>
Date:   Thu May 22 19:08:45 2025 -0400

    Adding Fastly NGWAF plugin

commit 8a7c9196298fefafdc4d696e105cae07b2135594 (tag: v2.3.2-asi-2b94868)
Author: Josh DeWald <josh.dewald@recordedfuture.com>
Date:   Thu Jan 2 10:52:31 2025 -0800

    First pass at disabling some less-than-useful checks (For our purposes)
    
    * CacheWall - disabled the matches that simply show Varnish is there
    * Envoy - disabled entirely. Knowing Envoy is there is just a tech detection
    * AWSWAF - disabled everything but one that triggers on an active rule
```